### PR TITLE
Configure unit, component, and integration testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules/
 root-solar/
+playwright-report/
+test-results/
+blob-report/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "scripts": {
-    "start": "node src/server.ts"
+    "start": "node src/server.ts",
+    "test": "pnpm run test:unit && pnpm run test:component && pnpm run test:integration",
+    "test:unit": "node --experimental-strip-types --test \"src/**/*.unit.test.ts\"",
+    "test:component": "playwright test -c playwright-ct.config.ts",
+    "test:integration": "playwright test -c playwright.config.ts"
   },
   "type": "module",
   "dependencies": {
@@ -28,6 +32,12 @@
     "surrealdb": "^1.3.2",
     "wouter": "^3.7.1",
     "zod": "^4.1.5"
+  },
+  "devDependencies": {
+    "@playwright/experimental-ct-react": "^1.51.1",
+    "@playwright/test": "^1.51.1",
+    "@vitejs/plugin-react": "^4.3.2",
+    "sass": "^1.83.4"
   },
   "packageManager": "pnpm@10.15.1"
 }

--- a/package.json
+++ b/package.json
@@ -34,9 +34,7 @@
     "zod": "^4.1.5"
   },
   "devDependencies": {
-    "@playwright/experimental-ct-react": "^1.51.1",
     "@playwright/test": "^1.51.1",
-    "@vitejs/plugin-react": "^4.3.2",
     "sass": "^1.83.4"
   },
   "packageManager": "pnpm@10.15.1"

--- a/playwright-ct.config.ts
+++ b/playwright-ct.config.ts
@@ -1,19 +1,31 @@
-import { defineConfig } from "@playwright/experimental-ct-react";
-import react from "@vitejs/plugin-react";
+import { defineConfig, devices } from "@playwright/test";
+
+const HOST = "127.0.0.1";
+const PORT = 4174;
+const BASE_URL = `http://${HOST}:${PORT}`;
 
 export default defineConfig({
   testDir: "./src",
   testMatch: /.*\\.component\\.test\\.(ts|tsx)$/,
-  snapshotDir: "./src/__tests__/__snapshots__",
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
   use: {
-    ctPort: 3100,
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
+    headless: true,
   },
-  ctViteConfig: {
-    plugins: [react()],
-    css: {
-      modules: {
-        localsConvention: "camelCaseOnly",
+  webServer: {
+    command: "pnpm rsbuild dev --host 127.0.0.1 --port 4174",
+    url: BASE_URL,
+    timeout: 120000,
+    reuseExistingServer: !process.env.CI,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
       },
     },
-  },
+  ],
 });

--- a/playwright-ct.config.ts
+++ b/playwright-ct.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "@playwright/experimental-ct-react";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  testDir: "./src",
+  testMatch: /.*\\.component\\.test\\.(ts|tsx)$/,
+  snapshotDir: "./src/__tests__/__snapshots__",
+  use: {
+    ctPort: 3100,
+  },
+  ctViteConfig: {
+    plugins: [react()],
+    css: {
+      modules: {
+        localsConvention: "camelCaseOnly",
+      },
+    },
+  },
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const HOST = "127.0.0.1";
+const PORT = 4173;
+const BASE_URL = `http://${HOST}:${PORT}`;
+
+export default defineConfig({
+  testDir: "./src",
+  testMatch: /.*\\.integration\\.test\\.(ts|tsx)$/, 
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
+    headless: true,
+  },
+  webServer: {
+    command: "pnpm rsbuild dev --host 127.0.0.1 --port 4173",
+    url: BASE_URL,
+    timeout: 120000,
+    reuseExistingServer: !process.env.CI,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+      },
+    },
+  ],
+});

--- a/src/__tests__/app.integration.test.ts
+++ b/src/__tests__/app.integration.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("application", () => {
+  test("renders the landing page", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByRole("heading", { level: 1 })).toHaveText(
+      "Life shares a common root.",
+    );
+  });
+});

--- a/src/__tests__/component.fixture.ts
+++ b/src/__tests__/component.fixture.ts
@@ -1,0 +1,44 @@
+import type { Locator } from "@playwright/test";
+import { test as base } from "@playwright/test";
+
+type MountOptions = {
+  props?: Record<string, unknown>;
+  searchParams?: Record<string, string>;
+};
+
+type Fixtures = {
+  mount: (componentName: string, options?: MountOptions) => Promise<Locator>;
+};
+
+const toSlug = (value: string): string =>
+  value
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .replace(/[^a-z0-9]+/gi, "-")
+    .replace(/^-+|-+$/g, "")
+    .toLowerCase();
+
+export const test = base.extend<Fixtures>({
+  mount: async ({ page }, use) => {
+    await use(async (componentName, options = {}) => {
+      const slug = toSlug(componentName);
+      const params = new URLSearchParams(options.searchParams);
+
+      if (options.props) {
+        params.set("props", JSON.stringify(options.props));
+      }
+
+      const query = params.toString();
+      const url = `/__component__/${encodeURIComponent(slug)}${
+        query ? `?${query}` : ""
+      }`;
+
+      await page.goto(url);
+      await page.waitForSelector("[data-component-root]");
+
+      return page.locator("[data-component-root]");
+    });
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/src/__tests__/hero.component.test.tsx
+++ b/src/__tests__/hero.component.test.tsx
@@ -1,10 +1,8 @@
-import { expect, test } from "@playwright/experimental-ct-react";
-
-import Hero from "../Hero.tsx";
+import { expect, test } from "./component.fixture";
 
 test.describe("Hero component", () => {
   test("renders the headline", async ({ mount }) => {
-    const component = await mount(<Hero />);
+    const component = await mount("Hero");
     await expect(component.getByRole("heading", { level: 1 })).toHaveText(
       "Life shares a common root.",
     );

--- a/src/__tests__/hero.component.test.tsx
+++ b/src/__tests__/hero.component.test.tsx
@@ -1,0 +1,12 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+
+import Hero from "../Hero.tsx";
+
+test.describe("Hero component", () => {
+  test("renders the headline", async ({ mount }) => {
+    const component = await mount(<Hero />);
+    await expect(component.getByRole("heading", { level: 1 })).toHaveText(
+      "Life shares a common root.",
+    );
+  });
+});

--- a/src/component-tests/ComponentHarness.tsx
+++ b/src/component-tests/ComponentHarness.tsx
@@ -1,0 +1,75 @@
+import type { ComponentType, ReactElement } from "react";
+import { useMemo } from "react";
+
+import Axiom from "../Axiom.tsx";
+import Axioms from "../Axioms.tsx";
+import Footer from "../Footer.tsx";
+import Header from "../Header.tsx";
+import Hero from "../Hero.tsx";
+import Main from "../Main.tsx";
+import NetworkStatusIndicator from "../NetworkStatusIndicator.tsx";
+
+const registry: Record<string, ComponentType<Record<string, unknown>>> = {
+  axiom: Axiom,
+  axioms: Axioms,
+  footer: Footer,
+  header: Header,
+  hero: Hero,
+  main: Main,
+  "network-status-indicator": NetworkStatusIndicator,
+};
+
+const normalizeKey = (value: string): string =>
+  value
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .replace(/[^a-z0-9]+/gi, "-")
+    .replace(/^-+|-+$/g, "")
+    .toLowerCase();
+
+const parseProps = (search: string): Record<string, unknown> | undefined => {
+  if (!search) {
+    return undefined;
+  }
+
+  const params = new URLSearchParams(search);
+  const raw = params.get("props");
+
+  if (!raw) {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    return typeof parsed === "object" && parsed !== null ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const ComponentHarness = ({
+  componentName,
+}: {
+  componentName?: string;
+}): ReactElement => {
+  const search = typeof window === "undefined" ? "" : window.location.search;
+  const componentProps = useMemo(() => parseProps(search), [search]);
+  const key = componentName ? normalizeKey(componentName) : "";
+  const Component = registry[key];
+
+  if (!Component) {
+    return (
+      <div data-component-root role="alert">
+        Unknown component: {componentName ?? "(unspecified)"}
+      </div>
+    );
+  }
+
+  return (
+    <div data-component-root>
+      <Component {...(componentProps ?? {})} />
+    </div>
+  );
+};
+
+export default ComponentHarness;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ import Header from "./Header.tsx";
 import Hero from "./Hero.tsx";
 import Main from "./Main.tsx";
 import Footer from "./Footer.tsx";
+import ComponentHarness from "./component-tests/ComponentHarness.tsx";
 
 import "./index.css";
 
@@ -14,6 +15,11 @@ createRoot(document.getElementById("root")).render(
     <Header />
     <Route path="/">
       <Hero />
+    </Route>
+    <Route path="/__component__/:componentName">
+      {(params) => (
+        <ComponentHarness componentName={params?.componentName} />
+      )}
     </Route>
     <Main />
     <Footer />

--- a/src/net/__tests__/runtime.unit.test.ts
+++ b/src/net/__tests__/runtime.unit.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+
+import type { SentimentNetwork, SentimentNetworkStatus } from "../index.ts";
+import {
+  clearSentimentNetwork,
+  getSentimentNetwork,
+  getSentimentNetworkStatus,
+  registerSentimentNetwork,
+} from "../runtime.ts";
+
+type StatusListener = (status: SentimentNetworkStatus) => void;
+
+const createSentimentNetworkStub = (initialStatus: SentimentNetworkStatus) => {
+  let currentStatus = initialStatus;
+  let listeners: StatusListener[] = [];
+
+  const network: SentimentNetwork = {
+    protocol: "test-protocol",
+    async querySentiment() {
+      return null;
+    },
+    async close() {
+      listeners = [];
+    },
+    getStatus() {
+      return currentStatus;
+    },
+    onStatusChange(listener) {
+      listeners.push(listener);
+      return () => {
+        listeners = listeners.filter((candidate) => candidate !== listener);
+      };
+    },
+  };
+
+  return {
+    network,
+    emit(status: SentimentNetworkStatus) {
+      currentStatus = status;
+      for (const listener of listeners) {
+        listener(status);
+      }
+    },
+    listenerCount() {
+      return listeners.length;
+    },
+  };
+};
+
+describe("net/runtime", () => {
+  afterEach(() => {
+    clearSentimentNetwork();
+  });
+
+  it("tracks the active network instance and status updates", () => {
+    const initialStatus: SentimentNetworkStatus = {
+      state: "ready",
+      peerId: "peer-id",
+      protocol: "test-protocol",
+    };
+    const stub = createSentimentNetworkStub(initialStatus);
+
+    registerSentimentNetwork(stub.network);
+    assert.equal(getSentimentNetwork(), stub.network);
+    assert.deepEqual(getSentimentNetworkStatus(), initialStatus);
+
+    const nextStatus: SentimentNetworkStatus = {
+      state: "error",
+      message: "boom",
+    };
+    stub.emit(nextStatus);
+    assert.deepEqual(getSentimentNetworkStatus(), nextStatus);
+  });
+
+  it("clears the active network and resets status to offline", () => {
+    const stub = createSentimentNetworkStub({
+      state: "ready",
+      peerId: "peer-id",
+      protocol: "test-protocol",
+    });
+    registerSentimentNetwork(stub.network);
+    assert.equal(stub.listenerCount(), 1);
+
+    stub.emit({ state: "error", message: "failure" });
+    clearSentimentNetwork();
+
+    assert.equal(getSentimentNetwork(), null);
+    assert.equal(stub.listenerCount(), 0);
+    assert.deepEqual(getSentimentNetworkStatus(), { state: "offline" });
+
+    stub.emit({
+      state: "ready",
+      peerId: "peer-id",
+      protocol: "test-protocol",
+    });
+    assert.deepEqual(getSentimentNetworkStatus(), { state: "offline" });
+  });
+});


### PR DESCRIPTION
## Summary
- add Node test runner scripts and Playwright dev dependencies to package.json and ignore Playwright output directories
- create Playwright configurations for component and integration testing that mount RSBuild locally
- add initial unit, component, and integration tests for the sentiment network runtime and landing page

## Testing
- `pnpm run test:unit`
- `pnpm run test:component` *(fails: Playwright CLI is not available in this environment)*
- `pnpm run test:integration` *(fails: Playwright CLI is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9276dc754832193793c48e983bf2c